### PR TITLE
chapter02-add-visualizing-filesystem-script-using-PlatformResolver-for-home

### DIFF
--- a/01-02-QuickStart.txt
+++ b/01-02-QuickStart.txt
@@ -19,7 +19,7 @@ c @ RSCanvasController.
 c open
 
 -----------------------------
-path := '/Users/alexandrebergel/Desktop'.
+path := PlatformResolver forCurrentPlatform home / 'Desktop'.
 extensions := 
 	{ 'pdf' -> Color red. 'mov' -> Color blue } asDictionary.
 allFilesUnderPath := path asFileReference allChildren.


### PR DESCRIPTION
Use PlatformResolver to avoid the reader to modify her home's path.